### PR TITLE
.containerignore allows initctl_faker.

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,4 +1,5 @@
 
-# Ignore everything but the Containerfile.
+# Ignore everything but the Containerfile and specific files.
 *
 !Containerfile
+!initctl_faker


### PR DESCRIPTION
See #1 for more details.